### PR TITLE
fix: remove unnecessary async behavior from pipeline route

### DIFF
--- a/runner/app/routes/audio_to_text.py
+++ b/runner/app/routes/audio_to_text.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -90,7 +89,7 @@ def parse_return_timestamps(value: str) -> Union[bool, str]:
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def audio_to_text(
+def audio_to_text(
     audio: Annotated[
         UploadFile, File(description="Uploaded audio file to be transcribed.")
     ],
@@ -156,8 +155,9 @@ async def audio_to_text(
         )
 
     try:
-
-        return await asyncio.to_thread(pipeline, audio=audio, return_timestamps=return_timestamps, duration=duration)
+        return pipeline(
+            audio=audio, return_timestamps=return_timestamps, duration=duration
+        )
         
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):

--- a/runner/app/routes/image_to_image.py
+++ b/runner/app/routes/image_to_image.py
@@ -1,5 +1,3 @@
-import asyncio
-from functools import partial
 import logging
 import os
 import random
@@ -71,7 +69,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def image_to_image(
+def image_to_image(
     prompt: Annotated[
         str,
         Form(description="Text prompt(s) to guide image generation."),
@@ -184,21 +182,19 @@ async def image_to_image(
     has_nsfw_concept = []
     for seed in seeds:
         try:
-            pipeline_call = partial(pipeline, 
-                                    prompt=prompt,
-                                    image=image,
-                                    strength=strength,
-                                    loras=loras,
-                                    guidance_scale=guidance_scale,
-                                    image_guidance_scale=image_guidance_scale,
-                                    negative_prompt=negative_prompt,
-                                    safety_check=safety_check,
-                                    seed=seed,
-                                    num_images_per_prompt=1,
-                                    num_inference_steps=num_inference_steps,
-                                    scheduler=scheduler
-                                )
-            imgs, nsfw_checks = await asyncio.to_thread(pipeline_call)
+            imgs, nsfw_checks = pipeline(
+                prompt=prompt,
+                image=image,
+                strength=strength,
+                loras=loras,
+                guidance_scale=guidance_scale,
+                image_guidance_scale=image_guidance_scale,
+                negative_prompt=negative_prompt,
+                safety_check=safety_check,
+                seed=seed,
+                num_images_per_prompt=1,
+                num_inference_steps=num_inference_steps,
+            )
         except Exception as e:
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/image_to_text.py
+++ b/runner/app/routes/image_to_text.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -65,7 +64,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def image_to_text(
+def image_to_text(
     image: Annotated[
         UploadFile, File(description="Uploaded image to transform with the pipeline.")
     ],
@@ -106,8 +105,7 @@ async def image_to_text(
 
     image = Image.open(image.file).convert("RGB")
     try:
-        out = await asyncio.to_thread(pipeline, prompt=prompt, image=image)
-        return ImageToTextResponse(text=out)
+        return ImageToTextResponse(text=pipeline(prompt=prompt, image=image))
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -1,5 +1,3 @@
-import asyncio
-from functools import partial
 import logging
 import os
 import random
@@ -71,7 +69,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def image_to_video(
+def image_to_video(
     image: Annotated[
         UploadFile,
         File(description="Uploaded image to generate a video from."),
@@ -159,19 +157,18 @@ async def image_to_video(
         seed = random.randint(0, 2**32 - 1)
 
     try:
-        pipeline_call = partial(pipeline,
-                                image=Image.open(image.file).convert("RGB"),
-                                height=height,
-                                width=width,
-                                fps=fps,
-                                motion_bucket_id=motion_bucket_id,
-                                noise_aug_strength=noise_aug_strength,
-                                num_inference_steps=num_inference_steps,
-                                safety_check=safety_check,
-                                seed=seed,
-                        )
-        
-        batch_frames, has_nsfw_concept = await asyncio.to_thread(pipeline_call)
+        batch_frames, has_nsfw_concept = pipeline(
+            image=Image.open(image.file).convert("RGB"),
+            height=height,
+            width=width,
+            fps=fps,
+            motion_bucket_id=motion_bucket_id,
+            noise_aug_strength=noise_aug_strength,
+            num_inference_steps=num_inference_steps,
+            safety_check=safety_check,
+            seed=seed,
+        )
+
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/segment_anything_2.py
+++ b/runner/app/routes/segment_anything_2.py
@@ -1,5 +1,3 @@
-import asyncio
-from functools import partial
 import logging
 import os
 from typing import Annotated, Dict, Tuple, Union
@@ -72,7 +70,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def segment_anything_2(
+def segment_anything_2(
     image: Annotated[
         UploadFile, File(description="Image to segment.", media_type="image/*")
     ],
@@ -174,16 +172,16 @@ async def segment_anything_2(
 
     try:
         image = Image.open(image.file).convert("RGB")
-        pipeline_call = partial(pipeline,
-                                image=image,
-                                point_coords=point_coords,
-                                point_labels=point_labels,
-                                box=box,
-                                mask_input=mask_input,
-                                multimask_output=multimask_output,
-                                return_logits=return_logits,
-                                normalize_coords=normalize_coords)
-        masks, scores, low_res_mask_logits = await asyncio.to_thread(pipeline_call)
+        masks, scores, low_res_mask_logits = pipeline(
+            image,
+            point_coords=point_coords,
+            point_labels=point_labels,
+            box=box,
+            mask_input=mask_input,
+            multimask_output=multimask_output,
+            return_logits=return_logits,
+            normalize_coords=normalize_coords,
+        )
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import random
@@ -153,7 +152,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def text_to_image(
+def text_to_image(
     params: TextToImageParams,
     pipeline: Pipeline = Depends(get_pipeline),
     token: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
@@ -197,7 +196,7 @@ async def text_to_image(
         params.seed = seed
         kwargs = {k: v for k, v in params.model_dump().items() if k != "model_id"}
         try:
-            imgs, nsfw_check = await asyncio.to_thread(pipeline, **kwargs)
+            imgs, nsfw_check = pipeline(**kwargs)
         except Exception as e:
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 # TODO: Investigate why not all VRAM memory is cleared.

--- a/runner/app/routes/text_to_speech.py
+++ b/runner/app/routes/text_to_speech.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import time
@@ -94,7 +93,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def text_to_speech(
+def text_to_speech(
     params: TextToSpeechParams,
     pipeline: Pipeline = Depends(get_pipeline),
     token: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
@@ -128,7 +127,7 @@ async def text_to_speech(
 
     try:
         start = time.time()
-        out = await asyncio.to_thread(pipeline, params)
+        out = pipeline(params)
         logger.info(f"TextToSpeechPipeline took {time.time() - start} seconds.")
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):

--- a/runner/app/routes/upscale.py
+++ b/runner/app/routes/upscale.py
@@ -1,4 +1,3 @@
-import asyncio
 from functools import partial
 import logging
 import os
@@ -70,7 +69,7 @@ RESPONSES = {
     responses=RESPONSES,
     include_in_schema=False,
 )
-async def upscale(
+def upscale(
     prompt: Annotated[
         str,
         Form(description="Text prompt(s) to guide upscaled image generation."),
@@ -134,7 +133,13 @@ async def upscale(
                                 num_inference_steps=num_inference_steps,
                                 safety_check=safety_check,
                                 seed=seed)
-        images, has_nsfw_concept = await asyncio.to_thread(pipeline_call)
+        images, has_nsfw_concept = pipeline(
+            prompt=prompt,
+            image=image,
+            num_inference_steps=num_inference_steps,
+            safety_check=safety_check,
+            seed=seed,
+        )
     except Exception as e:
         if isinstance(e, torch.cuda.OutOfMemoryError):
             # TODO: Investigate why not all VRAM memory is cleared.


### PR DESCRIPTION
This pull request removes the `async` keyword from the pipeline route, as it is not needed for our use case. We only allow one inference request at a time, and FastAPI already handles request threading without requiring `async`. Removing it simplifies the implementation while maintaining expected behavior.